### PR TITLE
Corrected carryover case in add_vector function

### DIFF
--- a/include/real/exact_number.hpp
+++ b/include/real/exact_number.hpp
@@ -78,9 +78,9 @@ namespace boost {
                         T max = std::max(lhs_digit, rhs_digit);
                         if (min <= base/2) {
                             T remaining = base/2 - min;
-                            digit = (max - (base + 1)/2) - remaining - 1;
+                            digit = (max - (base - 1)/2) - remaining - 2;
                         } else {
-                            digit = (min - base/2) + (max - (base + 1)/2) - 1;
+                            digit = (min - base/2) + (max - (base - 1)/2) - 2;
                         }
                         carry = 1;
                     }

--- a/include/real/exact_number.hpp
+++ b/include/real/exact_number.hpp
@@ -78,9 +78,9 @@ namespace boost {
                         T max = std::max(lhs_digit, rhs_digit);
                         if (min <= base/2) {
                             T remaining = base/2 - min;
-                            digit = (max - base/2) - remaining - 2;
+                            digit = (max - (base + 1)/2) - remaining - 1;
                         } else {
-                            digit = (min - base/2) + (max - base/2) - 2;
+                            digit = (min - base/2) + (max - (base + 1)/2) - 1;
                         }
                         carry = 1;
                     }


### PR DESCRIPTION
In the carry-over scenario, digit=max+min-base-1. As division a/b means floor(a/b), we use the identity that base=floor(base/2)+floor((base-1)/2)+1.
(Here we take (base-1)/2 to avoid overflow.)
So instead of subtracting base/2 from max, we should rather subtract (base-1)/2-1 from max, otherwise it would lead to an incorrect result for even bases.