### PR TITLE
Optimizing math functions like exp, log and trigonometric

### DIFF
--- a/include/real/exact_number.hpp
+++ b/include/real/exact_number.hpp
@@ -1965,6 +1965,38 @@ namespace boost {
             bool is_integral() { 
                    return digits.size() <= (size_t) exponent;
             }
+            
+            /**
+             * @brief Finds the floor of this, i.e. greatest integer smaller than this.
+             */
+            void floor() {
+                if (this->positive) {
+                    if (this->exponent < 0) {
+                        this->digits.clear();
+                        this->digits.push_back(0);
+                        this->exponent = 0;
+                    }
+                    else {
+                        while (this->digits.size() > this->exponent) {
+                            this->digits.pop_back();
+                        }
+                    }
+                }
+                else {
+                    if (this->exponent < 0) {
+                        this->digits.clear();
+                        this->digits.push_back(1);
+                        this->exponent = 1;
+                    }
+                    else {
+                        while (this->digits.size() > this->exponent) {
+                            this->digits.pop_back();
+                        }
+                        static exact_number<T> one_exact("1");
+                        this->add_vector(one_exact);
+                    }
+                }
+            }
 
         };
 

--- a/include/real/irrational_helpers.hpp
+++ b/include/real/irrational_helpers.hpp
@@ -55,89 +55,6 @@ namespace boost {
             /// @TODO: figure out how to avoid unnecessary recalculation by saving
             // some information from the previous iteration.
 
-
-            template <typename T = int>
-            T pi_nth_digit(unsigned int n) {
-                // Chudnovsky Algorithm
-                // pi = C * ( sum_from_k=0_to_k=x (Mk * Lk / Xk) )^(-1) 
-                // increasing x you get more precise pi
-
-                static const boost::real::real_explicit<T> real_k("6");
-                static const boost::real::real_explicit<T> real_m("1");
-                static const boost::real::real_explicit<T> real_l("13591409");
-                static const boost::real::real_explicit<T> real_l0("545140134");
-                static const boost::real::real_explicit<T> real_x("1");
-                static const boost::real::real_explicit<T> real_x0("-262537412640768000");
-                static const boost::real::real_explicit<T> real_s("13591409");
-
-                // real_c is constant C in the above formula
-                // its actual value is C = 426880 * sqrt(10005)
-                // following approximation for C can be removed 
-                // once the square root function is implemented
-                static const boost::real::real<T> real_c("42698670.6663333958177128891606596082733208840025090828008380071788526051574575942163017999114556686013457371674940804113922927361812667281931368821705825634600667987664834607957359835523339854848545832762473774912507545850325782197456759912124003920153233212768354462964858373556973060121234587580491432166");
-
-                exact_number<T> K = real_k.get_exact_number();
-                exact_number<T> L = real_l.get_exact_number();
-                exact_number<T> M = real_m.get_exact_number();
-                exact_number<T> X = real_x.get_exact_number();
-                exact_number<T> S = real_s.get_exact_number();
-
-                static exact_number<T> L0 = real_l0.get_exact_number();
-                static exact_number<T> X0 = real_x0.get_exact_number();
-                static exact_number<T> _16(std::vector<T> {16}, 1, true);
-                static exact_number<T> _12(std::vector<T> {12}, 1, true);
-                static exact_number<T> one("1");
-
-                static boost::real::const_precision_iterator<T> real_c_itr = real_c.get_real_itr();
-                real_c_itr.set_maximum_precision(n + 1);
-                const exact_number<T> C = real_c_itr.cend().get_interval().lower_bound;
-
-
-                bool nth_digit_found = false;
-                bool first_iteration_over = false;
-
-                exact_number<T> iteration_number = one;
-                exact_number<T> prev_pi;
-                exact_number<T> pi;
-                exact_number<T> error;
-                const exact_number<T> max_error(std::vector<T> {1}, -(n + 1), true);
-
-                do {  
-                    exact_number<T> temp = K * K * K - _16 * K;
-                    temp.divide_vector(iteration_number * iteration_number * iteration_number, n + 1, true);
-                    M *= temp;
-                    X *= X0;
-                    L += L0;
-                    K += _12;
-
-                    temp = M * L;
-                    temp.divide_vector(X, n + 1, false);
-                    S += temp;
-
-                    temp = C;
-                    temp.divide_vector(S, n + 1, false);
-
-                    pi = temp;
-                    if (!first_iteration_over) {
-                        prev_pi = pi;
-                        first_iteration_over = true;
-                        iteration_number += one;
-                    } else {
-                        error = pi - prev_pi;
-                        error.positive = true;
-
-                        if (error < max_error) {
-                            nth_digit_found = true;
-                        }
-                        iteration_number += one;
-                        prev_pi = pi;
-                    }
-
-                } while (!nth_digit_found);
-
-                return pi[n];
-            }
-
             /**
              * @brief Returns the exact number version of Pi
              * 
@@ -145,7 +62,7 @@ namespace boost {
              * @return The exact number value of Pi
              */
             template <typename T = int>
-            exact_number<T> exact_pi(size_t max_error_exponent) {
+            exact_number<T> pi(size_t max_error_exponent) {
                 // Chudnovsky Algorithm
                 // pi = C * ( sum_from_k=0_to_k=x (Mk * Lk / Xk) )^(-1) 
                 // increasing x you get more precise pi
@@ -177,7 +94,7 @@ namespace boost {
                 static exact_number<T> one("1");
 
                 static boost::real::const_precision_iterator<T> real_c_itr = real_c.get_real_itr();
-                real_c_itr.set_maximum_precision(max_error_exponent + 1);
+                real_c_itr.set_maximum_precision(max_error_exponent);
                 const exact_number<T> C = real_c_itr.cend().get_interval().lower_bound;
 
 
@@ -188,22 +105,22 @@ namespace boost {
                 exact_number<T> prev_pi;
                 exact_number<T> pi;
                 exact_number<T> error;
-                const exact_number<T> max_error(std::vector<T> {1}, -(max_error_exponent + 1), true);
+                const exact_number<T> max_error(std::vector<T> {1}, -(max_error_exponent), true);
 
                 do {  
                     exact_number<T> temp = K * K * K - _16 * K;
-                    temp.divide_vector(iteration_number * iteration_number * iteration_number, max_error_exponent + 1, true);
+                    temp.divide_vector(iteration_number * iteration_number * iteration_number, max_error_exponent, true);
                     M *= temp;
                     X *= X0;
                     L += L0;
                     K += _12;
 
                     temp = M * L;
-                    temp.divide_vector(X, max_error_exponent + 1, false);
+                    temp.divide_vector(X, max_error_exponent, false);
                     S += temp;
 
                     temp = C;
-                    temp.divide_vector(S, max_error_exponent + 1, false);
+                    temp.divide_vector(S, max_error_exponent, false);
 
                     pi = temp;
                     if (!first_iteration_over) {
@@ -224,6 +141,17 @@ namespace boost {
                 } while (!nth_digit_found);
 
                 return pi;
+            }
+
+            /**
+             * @brief Returns the n-th digit of pi
+             * 
+             * @param n - The number digit index.
+             * @return n-th digit of pi
+             */
+            template <typename T = int>
+            T pi_nth_digit(unsigned int n) {
+                return pi<T>(n + 1)[n];
             }
         }
     }

--- a/include/real/irrational_helpers.hpp
+++ b/include/real/irrational_helpers.hpp
@@ -137,6 +137,94 @@ namespace boost {
 
                 return pi[n];
             }
+
+            /**
+             * @brief Returns the exact number version of Pi
+             * 
+             * @param max_error_exponent - Absolute Error in the result should be < 1*base^(-max_error_exponent)
+             * @return The exact number value of Pi
+             */
+            template <typename T = int>
+            exact_number<T> exact_pi(size_t max_error_exponent) {
+                // Chudnovsky Algorithm
+                // pi = C * ( sum_from_k=0_to_k=x (Mk * Lk / Xk) )^(-1) 
+                // increasing x you get more precise pi
+
+                static const boost::real::real_explicit<T> real_k("6");
+                static const boost::real::real_explicit<T> real_m("1");
+                static const boost::real::real_explicit<T> real_l("13591409");
+                static const boost::real::real_explicit<T> real_l0("545140134");
+                static const boost::real::real_explicit<T> real_x("1");
+                static const boost::real::real_explicit<T> real_x0("-262537412640768000");
+                static const boost::real::real_explicit<T> real_s("13591409");
+
+                // real_c is constant C in the above formula
+                // its actual value is C = 426880 * sqrt(10005)
+                // following approximation for C can be removed 
+                // once the square root function is implemented
+                static const boost::real::real<T> real_c("42698670.6663333958177128891606596082733208840025090828008380071788526051574575942163017999114556686013457371674940804113922927361812667281931368821705825634600667987664834607957359835523339854848545832762473774912507545850325782197456759912124003920153233212768354462964858373556973060121234587580491432166");
+
+                exact_number<T> K = real_k.get_exact_number();
+                exact_number<T> L = real_l.get_exact_number();
+                exact_number<T> M = real_m.get_exact_number();
+                exact_number<T> X = real_x.get_exact_number();
+                exact_number<T> S = real_s.get_exact_number();
+
+                static exact_number<T> L0 = real_l0.get_exact_number();
+                static exact_number<T> X0 = real_x0.get_exact_number();
+                static exact_number<T> _16(std::vector<T> {16}, 1, true);
+                static exact_number<T> _12(std::vector<T> {12}, 1, true);
+                static exact_number<T> one("1");
+
+                static boost::real::const_precision_iterator<T> real_c_itr = real_c.get_real_itr();
+                real_c_itr.set_maximum_precision(max_error_exponent + 1);
+                const exact_number<T> C = real_c_itr.cend().get_interval().lower_bound;
+
+
+                bool nth_digit_found = false;
+                bool first_iteration_over = false;
+
+                exact_number<T> iteration_number = one;
+                exact_number<T> prev_pi;
+                exact_number<T> pi;
+                exact_number<T> error;
+                const exact_number<T> max_error(std::vector<T> {1}, -(max_error_exponent + 1), true);
+
+                do {  
+                    exact_number<T> temp = K * K * K - _16 * K;
+                    temp.divide_vector(iteration_number * iteration_number * iteration_number, max_error_exponent + 1, true);
+                    M *= temp;
+                    X *= X0;
+                    L += L0;
+                    K += _12;
+
+                    temp = M * L;
+                    temp.divide_vector(X, max_error_exponent + 1, false);
+                    S += temp;
+
+                    temp = C;
+                    temp.divide_vector(S, max_error_exponent + 1, false);
+
+                    pi = temp;
+                    if (!first_iteration_over) {
+                        prev_pi = pi;
+                        first_iteration_over = true;
+                        iteration_number += one;
+                    } else {
+                        error = pi - prev_pi;
+                        error.positive = true;
+
+                        if (error < max_error) {
+                            nth_digit_found = true;
+                        }
+                        iteration_number += one;
+                        prev_pi = pi;
+                    }
+
+                } while (!nth_digit_found);
+
+                return pi;
+            }
         }
     }
 }

--- a/include/real/real_exception.hpp
+++ b/include/real/real_exception.hpp
@@ -124,6 +124,12 @@ namespace boost {
             }
         };
 
+        struct max_precision_for_inverse_trigonometric_function_error : public std::exception {
+            const char * what() const throw () override {
+                return "Number is not in domain of this inverse trigonometric function";
+            }
+        };
+
         struct negative_integers_not_supported : public std::exception {
             const char * what() const throw () override {
                 return "Integer Power function only supports positive integers";

--- a/include/real/real_math.hpp
+++ b/include/real/real_math.hpp
@@ -172,16 +172,16 @@ namespace boost{
         }
 
         /**
-		 *  SQRT FUNCTION USING NEWTON'S METHOD
+		 *  SQUARE ROOT FUNCTION USING NEWTON'S METHOD
 		 * @brief: calculates square root of a exact_number using Newton's Method
-		 * @param: x: the exact number whose sqrt is to be found
+		 * @param: x: the exact number whose square root is to be found
 		 * @param: max_error_exponent: Absolute Error in the result should be < 1*base^(-max_error_exponent)
 		 * @param:  upper: if true: error lies in [0, +epsilon]
 		 *                  else: error lies in [-epsilon, 0], here epsilon = 1*base^(-max_error_exponent)
 		 * @author: Divyam Singal
 		 **/
         template<typename T>
-		exact_number<T> sqrt(exact_number<T> x, size_t max_error_exponent, bool upper) {
+		exact_number<T> square_root(exact_number<T> x, size_t max_error_exponent, bool upper) {
             // sqrt is defined for non negative numbers
             if (x.positive == false) {
                 throw sqrt_not_defined_for_negative_number();
@@ -567,7 +567,7 @@ namespace boost{
             
             // atan(x) = 2 * atan(x / (1 + sqrt(1 + x^2)))
             exact_number<T> red_x = x;
-            red_x.divide_vector(sqrt((x * x) + literals::one_exact<T>, max_error_exponent, upper) + literals::one_exact<T>, max_error_exponent, upper);
+            red_x.divide_vector(square_root((x * x) + literals::one_exact<T>, max_error_exponent, upper) + literals::one_exact<T>, max_error_exponent, upper);
             exact_number<T> result = tan_inverse(red_x, max_error_exponent, upper);
             result = result + result;
             result.up_to(max_error_exponent, upper);
@@ -597,14 +597,14 @@ namespace boost{
                 // acot(x) = pi + atan(1 / x)
                 exact_number<T> reciprocal("1");
                 reciprocal.divide_vector(x, max_error_exponent, upper);
-                return tan_inverse(reciprocal, max_error_exponent, upper) + boost::real::irrational::exact_pi(max_error_exponent);
+                return tan_inverse(reciprocal, max_error_exponent, upper) + boost::real::irrational::exact_pi<T>(max_error_exponent);
             }
             else { 
                 // -1 < x < 1
                 static exact_number<T> two("2");
 
                 // acot(x) = pi/2 - atan(x)
-                exact_number<T> result = boost::real::irrational::exact_pi(max_error_exponent);
+                exact_number<T> result = boost::real::irrational::exact_pi<T>(max_error_exponent);
                 result.divide_vector(two, max_error_exponent, upper);
                 result = result - tan_inverse(x, max_error_exponent, upper);
                 result = result.up_to(max_error_exponent, upper);
@@ -629,13 +629,13 @@ namespace boost{
             
             static exact_number<T> two("2");
             if (x == literals::one_exact<T>) {
-                exact_number<T> result = boost::real::irrational::exact_pi(max_error_exponent);
+                exact_number<T> result = boost::real::irrational::exact_pi<T>(max_error_exponent);
                 result.divide_vector(two, max_error_exponent, upper);
                 result = result.up_to(max_error_exponent, upper);
                 return result;
             }
             else if (x == literals::minus_one_exact<T>) {
-                exact_number<T> result = boost::real::irrational::exact_pi(max_error_exponent);
+                exact_number<T> result = boost::real::irrational::exact_pi<T>(max_error_exponent);
                 result.positive = true;
                 result.divide_vector(two, max_error_exponent, upper);
                 result = result.up_to(max_error_exponent, upper);
@@ -645,7 +645,7 @@ namespace boost{
             // asin(x) = atan(x / sqrt(1 - x * x))
             static exact_number<T> one("1");
             exact_number<T> x_tan = x;
-            x_tan.divide_vector(sqrt(one - x * x, max_error_exponent, upper), max_error_exponent, upper);
+            x_tan.divide_vector(square_root(one - x * x, max_error_exponent, upper), max_error_exponent, upper);
             return tan_inverse(x_tan, max_error_exponent, upper);
         }
 
@@ -666,7 +666,7 @@ namespace boost{
             
             static exact_number<T> two("2");
             // acos(x) = pi/2 - asin(x)
-            exact_number<T> result = boost::real::irrational::exact_pi(max_error_exponent);
+            exact_number<T> result = boost::real::irrational::exact_pi<T>(max_error_exponent);
             result.divide_vector(two, max_error_exponent, upper);
             result = result - sin_inverse(x, max_error_exponent, upper);
             result = result.up_to(max_error_exponent, upper);
@@ -738,7 +738,7 @@ namespace boost{
                 // x < 0, y >= 0
                 x_tan = y;
                 x_tan.divide_vector(x, max_error_exponent, upper);
-                exact_number<T> result = boost::real::irrational::exact_pi(max_error_exponent);
+                exact_number<T> result = boost::real::irrational::exact_pi<T>(max_error_exponent);
                 result = result + tan_inverse(x_tan, max_error_exponent, upper);
                 result.up_to(max_error_exponent, upper);
                 return result;
@@ -747,7 +747,7 @@ namespace boost{
                 // x < 0, y < 0
                 x_tan = y;
                 x_tan.divide_vector(x, max_error_exponent, upper);
-                exact_number<T> result = boost::real::irrational::exact_pi(max_error_exponent);
+                exact_number<T> result = boost::real::irrational::exact_pi<T>(max_error_exponent);
                 result.positive = false;
                 result = result + tan_inverse(x_tan, max_error_exponent, upper);
                 result.up_to(max_error_exponent, upper);
@@ -755,14 +755,14 @@ namespace boost{
             }
             else if (x == literals::zero_exact<T> && y > literals::zero_exact<T>) {
                 // x = 0, y > 0
-                exact_number<T> result = boost::real::irrational::exact_pi(max_error_exponent);
+                exact_number<T> result = boost::real::irrational::exact_pi<T>(max_error_exponent);
                 result.divide_vector(two, max_error_exponent, upper);
                 result.up_to(max_error_exponent, upper);
                 return result;
             }
             else if (x == literals::zero_exact<T> && y < literals::zero_exact<T>) {
                 // x = 0, y < 0
-                exact_number<T> result = boost::real::irrational::exact_pi(max_error_exponent);
+                exact_number<T> result = boost::real::irrational::exact_pi<T>(max_error_exponent);
                 result.positive = false;
                 result.divide_vector(two, max_error_exponent, upper);
                 result.up_to(max_error_exponent, upper);

--- a/include/real/real_math.hpp
+++ b/include/real/real_math.hpp
@@ -31,6 +31,10 @@ namespace boost{
 				x_pow *= num;
 				cur_term = x_pow;
 				cur_term.divide_vector(factorial, max_error_exponent, upper);
+
+                result.up_to(max_error_exponent, upper);
+                factorial.up_to(max_error_exponent, upper);
+                x_pow.up_to(max_error_exponent, upper);
 			}while(cur_term.abs() > max_error);
 			result = result.up_to(max_error_exponent, upper);
 			return result;
@@ -82,6 +86,9 @@ namespace boost{
 					cur_term.divide_vector(term_number, max_error_exponent, upper);
 					++term_number_int;
 					term_number = term_number + literals::one_exact<T>;
+
+                    result.up_to(max_error_exponent, upper);
+                    x_pow.up_to(max_error_exponent, upper);
 				}while(cur_term.abs() > max_error);
 				return result;
 			}
@@ -94,6 +101,9 @@ namespace boost{
 				cur_term.divide_vector(term_number, max_error_exponent, upper);
 				++term_number_int;
 				term_number = term_number + literals::one_exact<T>;
+
+                result.up_to(max_error_exponent, upper);
+                x_pow.up_to(max_error_exponent, upper);
 			}while(cur_term.abs() > max_error);
 			result = result.up_to(max_error_exponent, upper);
 			return result;
@@ -173,6 +183,10 @@ namespace boost{
 				factorial = factorial * ( two * term_number) * ( (two * term_number) + literals::one_exact<T>); // increasing the values of factorial by two
 				cur_term  = x_pow;
 				cur_term.divide_vector(factorial, max_error_exponent, upper);
+                
+                result = result.up_to(max_error_exponent, upper);
+                factorial = factorial.up_to(max_error_exponent, upper);
+                x_pow = x_pow.up_to(max_error_exponent, upper);
 			}while(cur_term.abs() > max_error);
 			result = result.up_to(max_error_exponent, upper);
 			return result;
@@ -212,7 +226,10 @@ namespace boost{
 				cur_term.divide_vector(factorial, max_error_exponent, upper);
 				++ term_number_int;
 				term_number = term_number + literals::one_exact<T>;
-				
+
+				result.up_to(max_error_exponent, upper);
+                factorial.up_to(max_error_exponent, upper);
+                cur_power.up_to(max_error_exponent, upper);
 			}while(cur_term.abs() > max_error);
 			result = result.up_to(max_error_exponent, upper);
 			return result;

--- a/include/real/real_math.hpp
+++ b/include/real/real_math.hpp
@@ -4,6 +4,7 @@
 #include <tuple>
 #include "real/exact_number.hpp"
 #include "real/real_exception.hpp"
+#include "real/irrational_helpers.hpp"
 
 namespace boost{
 	namespace real{
@@ -40,6 +41,16 @@ namespace boost{
 			return result;
 		}
 
+        /**
+		 *  EXPONENT FUNCTION USING BINARY EXPONENTIATION AND TAYLOR EXPANSION
+		 * @brief: calculates exponent of a exact_number using binary exponentiation
+         *  When num is sufficiently small, taylor expansion is used
+		 * @param: num: the exact number. whose exponent is to be found
+		 * @param: max_error_exponent: Absolute Error in the result should be < 1*base^(-max_error_exponent)
+		 * @param:  upper: if true: error lies in [0, +epsilon]
+		 *                  else: error lies in [-epsilon, 0], here epsilon = 1*base^(-max_error_exponent)
+		 * @author: Divyam Singal
+		 **/
         template<typename T>
         exact_number<T> exponent(exact_number<T> num, size_t max_error_exponent, bool upper) { 
             if (num >= literals::minus_one_exact<T> && num <= literals::one_exact<T>) {
@@ -127,6 +138,16 @@ namespace boost{
             return result;
         }
 
+        /**
+		 *  LOGARITHM(BASE e) FUNCTION USING RECURSION AND TAYLOR EXPANSION
+		 * @brief: calculates log(base e) of a exact_number using recursion
+         * When x is sufficiently small, taylor expansion is used
+		 * @param: x: the exact number. whose logarithm (ln(x)) is to be found
+		 * @param: max_error_exponent: Absolute Error in the result should be < 1*base^(-max_error_exponent)
+		 * @param:  upper: if true: error lies in [0, +epsilon]
+		 *                  else: error lies in [-epsilon, 0], here epsilon = 1*base^(-max_error_exponent)
+		 * @author: Divyam Singal
+		 **/
         template<typename T>
 		exact_number<T> logarithm(exact_number<T> x, size_t max_error_exponent, bool upper) {
             // log is only defined for numbers greater than 0
@@ -140,6 +161,7 @@ namespace boost{
                 result = logarithm_recurse(x, max_error_exponent, upper);
             }
             else {
+                // converting x to > 1
                 exact_number<T> rev_x = literals::one_exact<T>;
                 exact_number<T> minus_one = literals::minus_one_exact<T>;
                 rev_x.divide_vector(x, max_error_exponent, upper);
@@ -159,7 +181,7 @@ namespace boost{
 		 * @author: Vikram Singh Chundawat
 		 **/
 		template<typename T>
-		exact_number<T> sine(exact_number<T> x, size_t max_error_exponent, bool upper){
+		exact_number<T> sine_taylor(exact_number<T> x, size_t max_error_exponent, bool upper){
 			exact_number<T> result("0");
 			exact_number<T> term_number("0");
 			unsigned int term_number_int = 0;
@@ -192,6 +214,32 @@ namespace boost{
 			return result;
 		}
 
+        /**
+		 *  SINE FUNCTION USING ARGUMENT REDUCTION AND TAYLOR EXPANSION
+		 * @brief: calculates sin(x) of a exact_number using argument reduction
+         *  After reduction, taylor expansion is used
+		 * @param: x: the exact_number, representing angle in radian
+		 * @param: max_error_exponent: Absolute Error in the result should be < 1*base^(-max_error_exponent)
+		 * @param:  upper: if true: error lies in [0, +epsilon]
+		 *                  else: error lies in [-epsilon, 0], here epsilon = 1*base^(-max_error_exponent)
+		 * @author: Divyam Singal
+		 **/
+        template<typename T>
+		exact_number<T> sine(exact_number<T> x, size_t max_error_exponent, bool upper) {
+            exact_number<T> k = x;
+            exact_number<T> red_x = x;
+            static exact_number<T> two("2");
+
+            k.divide_vector(two, max_error_exponent, upper);
+            k.divide_vector(boost::real::irrational::exact_pi<T>(max_error_exponent), max_error_exponent, upper);
+            k.floor();
+
+            k = k * two * boost::real::irrational::exact_pi<T>(max_error_exponent); 
+            red_x -= k;
+
+            return sine_taylor(red_x, max_error_exponent, upper);
+        }
+
 		/**
 		 *  COSINE FUNCTION USING TAYLOR EXPANSION
 		 * @brief: calculates cos(x) of a exact_number using taylor expansion
@@ -202,7 +250,7 @@ namespace boost{
 		 * @author: Vikram Singh Chundawat
 		 **/
 		template<typename T>
-		exact_number<T> cosine(exact_number<T> x, size_t max_error_exponent, bool upper){
+		exact_number<T> cosine_taylor(exact_number<T> x, size_t max_error_exponent, bool upper){
 			exact_number<T> result("1");
 			exact_number<T> cur_term("0");
 			exact_number<T> square_x = x*x;
@@ -235,6 +283,32 @@ namespace boost{
 			return result;
 		}
 
+        /**
+		 *  COSINE FUNCTION USING ARGUMENT REDUCTION AND TAYLOR EXPANSION
+		 * @brief: calculates cos(x) of a exact_number using argument reduction
+         * After reduction, taylor expansion is used
+		 * @param: x: the exact_number, representing angle in radian
+		 * @param: max_error_exponent: Absolute Error in the result should be < 1*base^(-max_error_exponent)
+		 * @param:  upper: if true: error lies in [0, +epsilon]
+		 *                  else: error lies in [-epsilon, 0], here epsilon = 1*base^(-max_error_exponent)
+		 * @author: Divyam Singal
+		 **/
+        template<typename T>
+		exact_number<T> cosine(exact_number<T> x, size_t max_error_exponent, bool upper) {
+            exact_number<T> k = x;
+            exact_number<T> red_x = x;
+            static exact_number<T> two("2");
+
+            k.divide_vector(two, max_error_exponent, upper);
+            k.divide_vector(boost::real::irrational::exact_pi<T>(max_error_exponent), max_error_exponent, upper);
+            k.floor();
+
+            k = k * two * boost::real::irrational::exact_pi<T>(max_error_exponent); 
+            red_x -= k;
+
+            return cosine_taylor(red_x, max_error_exponent, upper);
+        }
+
 		 
 		 /**
 		 *  SINE AND COSINE FUNCTION USING TAYLOR EXPANSION
@@ -247,7 +321,7 @@ namespace boost{
 		 * @author: Vikram Singh Chundawat
 		 **/
 		template<typename T>
-		std::tuple<exact_number<T>, exact_number<T> > sin_cos(exact_number<T> x, size_t max_error_exponent, bool upper){
+		std::tuple<exact_number<T>, exact_number<T> > sin_cos_taylor(exact_number<T> x, size_t max_error_exponent, bool upper){
 			exact_number<T> sin_result("0");
 			exact_number<T> cos_result("0");
 			exact_number<T> cur_sin_term = x;
@@ -284,6 +358,33 @@ namespace boost{
 
 			return std::make_tuple(sin_result, cos_result);
 		}
+
+        /**
+		 *  SINE AND COSINE FUNCTION USING ARGUMENT REDUCTION AND TAYLOR EXPANSION
+		 * @brief: calculates cos(x) and sin(x) of a exact_number using argument reduction
+         * After reduction, taylor expansion is used
+		 * @param: x: the exact_number, representing angle in radian
+		 * @param: max_error_exponent: Absolute Error in the result should be < 1*base^(-max_error_exponent)
+		 * @param:  upper: if true: error lies in [0, +epsilon]
+		 *                  else: error lies in [-epsilon, 0], here epsilon = 1*base^(-max_error_exponent)
+		 * @return: a tuple containing sin(x) and cos(x)
+		 * @author: Divyam Singal
+		 **/
+        template<typename T>
+		std::tuple<exact_number<T>, exact_number<T> > sin_cos(exact_number<T> x, size_t max_error_exponent, bool upper){
+            exact_number<T> k = x;
+            exact_number<T> red_x = x;
+            static exact_number<T> two("2");
+
+            k.divide_vector(two, max_error_exponent, upper);
+            k.divide_vector(boost::real::irrational::exact_pi<T>(max_error_exponent), max_error_exponent, upper);
+            k.floor();
+
+            k = k * two * boost::real::irrational::exact_pi<T>(max_error_exponent); 
+            red_x -= k;
+
+            return sin_cos_taylor(red_x, max_error_exponent, upper);
+        }
 
 		/**
 		 *  TANGENT FUNCTION USING TAYLOR EXPANSION


### PR DESCRIPTION
1. Exponent: Optimized using binary exponentiation for large values. For exponent(1000), it gave an improvement in speed by taking 0.8s now as compared to 256s earlier. Also improved in cases where x<-1.
2. Logarithm: Wrote log(x)=log(x/2)+log(2), repeating until x is small enough. Also calculated log(2) only once. For log(100), it gave an improvement in speed by taking 5s now as compared to 437s earlier. Also improved in cases where x<1.
3. Trigonometric Functions: Performed argument reduction to reduce the number to [0,2PI). Then used Taylor series. For sin(10000), it gave an improvement in speed by taking 0.6s now as compared to 64s earlier. Implemented floor function for it.
4. Added sqrt and inverse trigonometric functions.

Also using up_to() at each iteration of taylor series to avoid extra computation. This also gave significant improvement in time.