### PR TITLE
Added editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,28 @@
+# EditorConfig is awesome: http://EditorConfig.org
+#
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_size = 4
+indent_style = space
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{cpp,hpp}]
+indent_size = 4
+indent_style = space
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[{Jamfile*,CMakeLists.txt,CMakeSettings.json,*.cmake}]
+indent_size = 2
+indent_style = space
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.yml]
+indent_size = 2
+indent_style = space
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
Added `.editorconfig` file, to avoid indentation errors and maintain a single convention for better practises.